### PR TITLE
fix: revert the `getMarker` function

### DIFF
--- a/src/AbstractMap.js
+++ b/src/AbstractMap.js
@@ -58,10 +58,13 @@ class AbstractMap {
     }
 
     getMarker(marker) {
-        const id = typeof marker === 'string' ? marker : marker.id;
-        return this.markers.find(m => {
-            return m.id === id;
-        });
+        if (typeof marker === 'string') {
+            marker = this.markers.find(m => {
+                return m.id === marker;
+            });
+        }
+
+        return marker;
     }
 
     getMarkerIcons() {


### PR DESCRIPTION
Otherwise, custom markers (such as the user marker) were broken.