### PR TITLE
Fit bounds padding

### DIFF
--- a/docs/references/fit-bounds.md
+++ b/docs/references/fit-bounds.md
@@ -4,7 +4,7 @@
 
 ## fitBounds
 
-> fitBounds(bounds, zoom = mapOptions.zoom)
+> fitBounds(bounds, zoom = mapOptions.zoom, padding = 50)
 
 Set zoom and the display area limits of the map.
 
@@ -17,3 +17,14 @@ The display area limits of the map.
 #### `zoom` - Number
 
 The zoom level.
+
+#### `padding` - Number | Object
+
+The padding around the display area limits in pixel.  
+If it's a number, all directions will have the same value.
+
+Object properties:
+- `top` - Number (optional, default `0`)
+- `right` - Number (optional, default `0`)
+- `bottom` - Number (optional, default `0`)
+- `left` - Number (optional, default `0`)

--- a/example/components/results.js
+++ b/example/components/results.js
@@ -120,6 +120,19 @@ var MyMap = /** @class */ (function () {
     MyMap.prototype.handleMouseEnterOnMarker = function (marker) {
         var _this = this;
         return function () {
+            /**
+             * NOTE: Set all non active markers to default icon for Mappy and Leaflet
+             *   prevent markers to not update correctly when showLabel is set to true
+             */
+            if (_this.attr.showLabel && (_this.attr.provider === 'mappy' || _this.attr.provider === 'leaflet')) {
+                _this.getMarkers().filter(function (m) {
+                    var type = _this.getMarkerIconType(m);
+                    return type !== 'active' && type !== 'default' && marker.id !== m.id;
+                }).forEach(function (m) {
+                    _this.setIconOnMarker(m, 'default');
+                });
+            }
+
             if (_this.getMarkerIconType(marker) !== 'active' && _this.getMarkerIconType(marker) !== 'hover') {
                 _this.setIconOnMarker(marker, 'hover');
                 _this.highlightLocation(marker.id);

--- a/example/data/locations.js
+++ b/example/data/locations.js
@@ -9,7 +9,7 @@ let locations = [];
 for (let i = 0; i < 20; i++) {
     const location = {
         _id: 'uuid' + i,
-        name: `Location name #${i}`,
+        name: `Location name #${i + 1}`,
         localisation: {
             coordinates: {
                 latitude: getRandomInRange(45, 46, 3),

--- a/src/providers/gmaps/Gmaps.js
+++ b/src/providers/gmaps/Gmaps.js
@@ -316,17 +316,38 @@ class GoogleMap extends AbstractMap {
         if (zoom < breakZoom + 1 && !this.isMinifiedMarkerIcons) {
             [].forEach.call(Object.keys(this.icons), key => {
                 const size = this.icons[key].scaledSize;
-                this.icons[key].scaledSize.width = size.width * minifier;
-                this.icons[key].scaledSize.height = size.height * minifier;
+                const width = size.width * minifier;
+                const height = size.height * minifier;
+
+                this.icons[key].scaledSize = new google.maps.Size(width, height);
+                this.icons[key].anchor = new google.maps.Point(width / 2, height);
             });
+            this.refreshAllMarkers();
+
             this.isMinifiedMarkerIcons = true;
         } else if (zoom > breakZoom && this.isMinifiedMarkerIcons) {
             [].forEach.call(Object.keys(this.icons), key => {
                 const size = this.icons[key].scaledSize;
-                this.icons[key].scaledSize.width = size.width / minifier;
-                this.icons[key].scaledSize.height = size.height / minifier;
+                const width = size.width / minifier;
+                const height = size.height / minifier;
+
+                this.icons[key].scaledSize = new google.maps.Size(width, height);
+                this.icons[key].anchor = new google.maps.Point(width / 2, height);
             });
+            this.refreshAllMarkers();
+
             this.isMinifiedMarkerIcons = false;
+        }
+    }
+
+    refreshAllMarkers() {
+        this.getMarkers().forEach(marker => {
+            const iconName = this.getMarkerIconType(marker);
+            marker.setIcon(this.icons[iconName]);
+        });
+
+        if (this.userMarker) {
+            this.userMarker.setIcon(this.icons.user);
         }
     }
 }

--- a/src/providers/gmaps/Gmaps.js
+++ b/src/providers/gmaps/Gmaps.js
@@ -285,8 +285,8 @@ class GoogleMap extends AbstractMap {
         return this.bounds.extend(position);
     }
 
-    fitBounds(bounds) {
-        this.map.fitBounds(bounds);
+    fitBounds(bounds, _zoom, padding = 50) {
+        this.map.fitBounds(bounds, padding);
     }
 
     panTo(position) {

--- a/src/providers/leaflet/Leaflet.js
+++ b/src/providers/leaflet/Leaflet.js
@@ -338,27 +338,40 @@ class Leaflet extends AbstractMap {
         if (zoom < breakZoom + 1 && !this.isMinifiedMarkerIcons) {
             [].forEach.call(Object.keys(this.icons), key => {
                 const size = this.icons[key].options.iconSize;
-                this.icons[key].options.iconSize = [size[0] * minifier, size[1] * minifier];
+                const width = size[0] * minifier;
+                const height = size[1] * minifier;
+
+                this.icons[key].options.iconSize = [width, height];
+                this.icons[key].options.iconAnchor = [width / 2, height];
             });
+
+            this.refreshAllMarkers();
+
             this.isMinifiedMarkerIcons = true;
-            this.updateAllMarkerIconsOnMap();
         } else if (zoom > breakZoom && this.isMinifiedMarkerIcons) {
             [].forEach.call(Object.keys(this.icons), key => {
                 const size = this.icons[key].options.iconSize;
-                this.icons[key].options.iconSize = [size[0] / minifier, size[1] / minifier];
+                const width = size[0] / minifier;
+                const height = size[1] / minifier;
+
+                this.icons[key].options.iconSize = [width, height];
+                this.icons[key].options.iconAnchor = [width / 2, height];
             });
+
+            this.refreshAllMarkers();
+
             this.isMinifiedMarkerIcons = false;
-            this.updateAllMarkerIconsOnMap();
         }
     }
 
-    updateAllMarkerIconsOnMap() {
-        [].forEach.call(this.markers, marker => {
-            this.setIconOnMarker(marker, marker.iconType, false);
+    refreshAllMarkers() {
+        this.getMarkers().forEach(marker => {
+            const iconName = this.getMarkerIconType(marker);
+            marker.setIcon(this.icons[iconName]);
         });
 
         if (this.userMarker) {
-            this.setIconOnMarker(this.userMarker, this.userMarker.iconType, false);
+            this.userMarker.setIcon(this.icons.user);
         }
     }
 }

--- a/src/providers/leaflet/Leaflet.js
+++ b/src/providers/leaflet/Leaflet.js
@@ -300,11 +300,19 @@ class Leaflet extends AbstractMap {
         return this.bounds.extend(position);
     }
 
-    fitBounds(bounds, zoom = this.mapOptions.zoom) {
-        this.map.fitBounds(bounds, {
-            padding: L.point(50, 50),
+    fitBounds(bounds, zoom = this.mapOptions.zoom, padding = 50) {
+        const options = {
             maxZoom: zoom
-        });
+        };
+
+        if (!isNaN(padding)) {
+            options['padding'] = L.point(padding, padding);
+        } else {
+            options['paddingTopLeft'] = L.point(padding.left || 0, padding.top || 0);
+            options['paddingBottomRight'] = L.point(padding.right || 0, padding.bottom || 0);
+        }
+
+        this.map.fitBounds(bounds, options);
     }
 
     panTo(position, zoom = this.mapOptions.locationZoom) {

--- a/src/providers/mappy/Mappy.js
+++ b/src/providers/mappy/Mappy.js
@@ -311,11 +311,19 @@ class Mappy extends AbstractMap {
         return this.bounds.extend(position);
     }
 
-    fitBounds(bounds, zoom = this.mapOptions.zoom) {
-        this.map.fitBounds(bounds, {
-            padding: L.point(50, 50),
+    fitBounds(bounds, zoom = this.mapOptions.zoom, padding = 50) {
+        const options = {
             maxZoom: zoom
-        });
+        };
+
+        if (!isNaN(padding)) {
+            options['padding'] = L.point(padding, padding);
+        } else {
+            options['paddingTopLeft'] = L.point(padding.left || 0, padding.top || 0);
+            options['paddingBottomRight'] = L.point(padding.right || 0, padding.bottom || 0);
+        }
+
+        this.map.fitBounds(bounds, options);
     }
 
     panTo(position, zoom = this.mapOptions.locationZoom) {

--- a/src/providers/mappy/Mappy.js
+++ b/src/providers/mappy/Mappy.js
@@ -349,27 +349,40 @@ class Mappy extends AbstractMap {
         if (zoom < breakZoom + 1 && !this.isMinifiedMarkerIcons) {
             [].forEach.call(Object.keys(this.icons), key => {
                 const size = this.icons[key].options.iconSize;
-                this.icons[key].options.iconSize = [size[0] * minifier, size[1] * minifier];
+                const width = size[0] * minifier;
+                const height = size[1] * minifier;
+
+                this.icons[key].options.iconSize = [width, height];
+                this.icons[key].options.iconAnchor = [width / 2, height];
             });
+
+            this.refreshAllMarkers();
+
             this.isMinifiedMarkerIcons = true;
-            this.updateAllMarkerIconsOnMap();
         } else if (zoom > breakZoom && this.isMinifiedMarkerIcons) {
             [].forEach.call(Object.keys(this.icons), key => {
                 const size = this.icons[key].options.iconSize;
-                this.icons[key].options.iconSize = [size[0] / minifier, size[1] / minifier];
+                const width = size[0] / minifier;
+                const height = size[1] / minifier;
+
+                this.icons[key].options.iconSize = [width, height];
+                this.icons[key].options.iconAnchor = [width / 2, height];
             });
+
+            this.refreshAllMarkers();
+
             this.isMinifiedMarkerIcons = false;
-            this.updateAllMarkerIconsOnMap();
         }
     }
 
-    updateAllMarkerIconsOnMap() {
-        [].forEach.call(this.markers, marker => {
-            this.setIconOnMarker(marker, marker.iconType, false);
+    refreshAllMarkers() {
+        this.getMarkers().forEach(marker => {
+            const iconName = this.getMarkerIconType(marker);
+            marker.setIcon(this.icons[iconName]);
         });
 
         if (this.userMarker) {
-            this.setIconOnMarker(this.userMarker, this.userMarker.iconType, false);
+            this.userMarker.setIcon(this.icons.user);
         }
     }
 }


### PR DESCRIPTION
## Features

- enable custom padding on `fitBounds` method

> `fitBounds(bounds[, zoom, padding])`
>
> `bounds` - map bounds
> `zoom` - number
> `padding` - number | {top?: number, right?: number, bottom?: number, left?: number}

## Fixes

- fix minified markers anchor position
- fix markers with label update on hover on example